### PR TITLE
fix: if command failed, return error result

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -1,4 +1,4 @@
-import { ResultAsync } from "npm:neverthrow@6.1.0";
+import { err, ok, ResultAsync } from "npm:neverthrow@6.1.0";
 
 const decoder = new TextDecoder();
 
@@ -29,10 +29,13 @@ export function yabai(
     stdout: "piped",
     stderr: "piped",
   });
-  return ResultAsync.fromPromise(
-    com.output().then((e) => decoder.decode(e.stdout)),
-    convertToError(),
-  );
+  return ResultAsync.fromPromise(com.output(), convertToError())
+    .andThen(
+      ({ success, stdout, stderr }) =>
+        success
+          ? ok(decoder.decode(stdout))
+          : err(new Error(decoder.decode(stderr))),
+    );
 }
 
 function convertToError(msg = "unknown error") {


### PR DESCRIPTION
SSIA
> before this commit return ok result always.
> only failed to `Deno.Command` failed, return err result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved how the application handles and decodes output from external commands, enhancing reliability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->